### PR TITLE
Transition from ufpy to awips python package

### DIFF
--- a/installers/RPMs/httpd-pypies/component.spec
+++ b/installers/RPMs/httpd-pypies/component.spec
@@ -34,8 +34,8 @@ Provides: mod_dav = %{version}-%{release}, httpd-suexec = %{version}-%{release}
 Provides: %name-mmn = %{mmn}
 Requires: %name-tools >= %{version}-%{release}
 Requires: awips2-pypies
-Requires: awips2-hdf5, awips2-python, awips2-python-dynamicserialize, awips2-python-h5py
-Requires: awips2-python-numpy, awips2-python-thrift, awips2-python-ufpy, awips2-python-werkzeug
+Requires: awips2-hdf5, awips2-python, awips2-python-awips, awips2-python-h5py
+Requires: awips2-python-numpy, awips2-python-werkzeug
 Requires: awips2-watchdog
 Packager: %{_build_site}
 


### PR DESCRIPTION
-Update rpm building to include awips2-python-awips (which includes awips, dynamicserialize, thrift packages), and remove rpm install dependencies on ufpy, dynamicserialize, and thrift -Update multiple python scripts across several repos to use awips instead of ufpy:
  -awips2
  -awips2-core
  -awips2-nativelib
  -awips2-ncep
  -awips2-rpm